### PR TITLE
Docker: organization in container image URL should be lowercase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG WAS_UI_TAG="main"
 
-FROM ghcr.io/HeyWillow/willow-application-server-ui:${WAS_UI_TAG} AS was-ui
+FROM ghcr.io/heywillow/willow-application-server-ui:${WAS_UI_TAG} AS was-ui
 
 FROM python:3.12.9-alpine3.21
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All you have to do is run Willow Application Server and connect to it. From ther
 ### Running WAS
 
 ```
-docker run --detach --name=willow-application-server --pull=always --network=host --restart=unless-stopped --volume=was-storage:/app/storage ghcr.io/HeyWillow/willow-application-server
+docker run --detach --name=willow-application-server --pull=always --network=host --restart=unless-stopped --volume=was-storage:/app/storage ghcr.io/heywillow/willow-application-server
 ```
 
 ### Building WAS


### PR DESCRIPTION
Fixes the following error in CI:

buildx failed with: ERROR: failed to solve: failed to parse stage name "ghcr.io/HeyWillow/willow-application-server-ui:main": invalid reference format: repository name (HeyWillow/willow-application-server-ui) must be lowercase