### PR TITLE
CI: set permissions on job

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   build_container:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This is best practice.

Reported-by: CodeQL