### PR TITLE
CI: group pydantic and pydantic-core updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,10 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    groups:
+      pydantic-and-core:
+        patterns:
+          - "pydantic"
+          - "pydantic-core"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot opened separate PRs for pydantic and pydantic-core. They both failed due to dependency conflict. This is an attempt to have dependabot group updates to both packages together.