### PR TITLE
main: always initialize app.command_endpoint to None

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -112,10 +112,10 @@ async def lifespan(app: FastAPI):
             log.error(f"failed to migrate user client config to database: {e}")
     app.connmgr = ConnMgr()
 
+    app.command_endpoint = None
     try:
         init_command_endpoint(app)
     except Exception as e:
-        app.command_endpoint = None
         log.error(f"failed to initialize command endpoint ({e})")
 
     app.notify_queue = NotifyQueue(connmgr=app.connmgr)


### PR DESCRIPTION
When WAS command mode is disabled, init_command_endpoint doesn't always throw an exception, so we don't always set app.command_endpoint. This can result in the follow exception in the WebSocket loop:

was[2448155]: 2025-04-30 07:57:50 ERROR    unhandled exception in WebSocket route: 'FastAPI' object has no attribute 'command_endpoint'

This in turn can result in a connection not being cleaned up from connmgr and possibly a duplicate client in it. If this happens, we're seeing the following error again while trying to send a command to a Willow:

RuntimeError: Unexpected ASGI message 'websocket.send', after sending 'websocket.close'.

Always initialize app.command_endpoint to None to fix this.