### PR TITLE
default_config: add was_mode

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -40,6 +40,7 @@
   "wake_confirmation": false,
   "wake_mode": "2CH_95",
   "wake_word": "alexa",
+  "was_mode": true,
   "wis_tts_url": "https://infer.tovera.io/api/tts",
   "wis_url": "https://infer.tovera.io/api/willow"
 }


### PR DESCRIPTION
It's time to enable WAS Command Endpoint by default for the upcoming 0.3.0 release. It can still be disabled in case people experience issues with it.