### PR TITLE
defaults: include WebSocket path in default WAS URL

### DIFF
--- a/default_nvs.json
+++ b/default_nvs.json
@@ -1,6 +1,6 @@
 {
   "WAS": {
-    "URL": "wss://was.local"
+    "URL": "wss://was.local/ws"
   },
   "WIFI": {
     "PSK": "mypassword",


### PR DESCRIPTION
WAS accepts Willow connections at /ws, so include the endpoint path in the default NVS URL.