### PR TITLE
requirements: bump pydantic dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,5 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
-    groups:
-      pydantic-and-core:
-        patterns:
-          - "pydantic"
-          - "pydantic-core"
     schedule:
       interval: "weekly"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ paho-mqtt==2.1.0
 pydantic==2.13.0
 pydantic-extra-types==2.11.1
 pydantic-settings==2.14.2
-pydantic_core==2.46.0
 pytest==9.1.1
 python-dotenv==1.2.2
 python-magic==0.4.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Jinja2==3.1.6
 MarkupSafe==3.0.3
 num2words==0.5.14
 paho-mqtt==2.1.0
-pydantic==2.13.0
+pydantic==2.13.4
 pydantic-extra-types==2.11.1
 pydantic-settings==2.14.2
 pytest==9.1.1


### PR DESCRIPTION
## Summary

- stop pinning `pydantic_core` directly and let Pydantic select its required core version
- remove the now-obsolete custom Dependabot group for Pydantic and Pydantic Core
- bump Pydantic from 2.13.0 to the latest stable release, 2.13.4

This avoids invalid combinations of Pydantic and Pydantic Core such as the one proposed by Dependabot in #252, while keeping the application dependency fully pinned.

## Validation

The branch is limited to dependency metadata changes. The repository's container build and test suite will validate the resolved dependency set in CI.

Closes: #252