### PR TITLE
Dockerfile: use build platform for UI artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION="3.24"
 ARG WAS_UI_TAG="main"
 
-FROM ghcr.io/heywillow/willow-application-server-ui:${WAS_UI_TAG} AS was-ui
+FROM --platform=$BUILDPLATFORM ghcr.io/heywillow/willow-application-server-ui:${WAS_UI_TAG} AS was-ui
 
 FROM alpine:${ALPINE_VERSION} AS build
 


### PR DESCRIPTION
The UI image only supplies prebuilt static files, so it does not need to match the target architecture. Pull it for the build platform to let Buildx reuse the available UI image during cross-platform builds while the application image continues to target the requested platform.