### PR TITLE
OTA: gate releases requiring SR model updates

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -1,3 +1,6 @@
+from semver import Version
+
+
 ALEMBIC_CONFIG = '/app/alembic.ini'
 DB_URL = 'sqlite:////app/storage/was.db'
 DIR_ASSET = '/app/storage/asset'
@@ -5,6 +8,9 @@ DIR_OTA = '/app/storage/ota'
 URL_WILLOW_RELEASES = 'https://worker.heywillow.org/api/release?format=was'
 URL_WILLOW_CONFIG = 'https://worker.heywillow.org/api/config'
 URL_WILLOW_TZ = 'https://worker.heywillow.org/api/asset?type=tz'
+
+# Willow 0.5 beta introduces SR model OTA, which WAS 0.3 cannot provide.
+WILLOW_MIN_SR_MODEL_OTA_VERSION = Version.parse("0.5.0-beta.0")
 
 STORAGE_USER_CLIENT_CONFIG = 'storage/user_client_config.json'
 STORAGE_USER_CONFIG = 'storage/user_config.json'

--- a/app/internal/was.py
+++ b/app/internal/was.py
@@ -14,6 +14,7 @@ from hashlib import sha256
 from logging import getLogger
 
 from num2words import num2words
+from semver import Version
 from websockets.sync.client import connect
 
 from app.db.main import get_config_db, get_nvs_db, save_config_to_db, save_nvs_to_db
@@ -28,6 +29,7 @@ from ..const import (
     STORAGE_USER_WAS,
     URL_WILLOW_RELEASES,
     URL_WILLOW_TZ,
+    WILLOW_MIN_SR_MODEL_OTA_VERSION,
 )
 
 
@@ -208,6 +210,18 @@ def get_release_url(was_url, version, platform):
 
     url = f"{scheme}://{parsed.netloc}/api/ota?version={version}&platform={platform}"
     return url
+
+
+def is_willow_release_compatible(version):
+    if version == "local":
+        return True
+
+    try:
+        release_version = Version.parse(version.removeprefix("v"))
+    except ValueError:
+        return True
+
+    return release_version < WILLOW_MIN_SR_MODEL_OTA_VERSION
 
 
 # TODO: Find a better way but we need to handle every error possible

--- a/app/pytest/api/test_ota.py
+++ b/app/pytest/api/test_ota.py
@@ -12,6 +12,14 @@ client = TestClient(app)
 
 
 class TestOta(unittest.TestCase):
+    def test_rejects_incompatible_release(self):
+        response = client.get("/api/ota?platform=ESP32-S3-BOX-3&version=0.5.0")
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == (
+            "This Willow release requires a newer Willow Application Server"
+        )
+
     def test_get_ota(self):
         mock_uri_bad = "/api/ota?platform=ESP32-S3-BOX-3&version=0.0.0-mock.0/../../.."
         mock_uri_good = "/api/ota?platform=ESP32-S3-BOX-3&version=0.0.0-mock.0"

--- a/app/pytest/api/test_release.py
+++ b/app/pytest/api/test_release.py
@@ -15,6 +15,8 @@ client = TestClient(app)
 mock_releases_was = [{
     "name": "0.0.0-mock.0",
     "tag_name": "0.0.0-mock.0",
+    "latest": True,
+    "was_compatible": True,
     "assets": [
         {
             "browser_download_url": "bogus",
@@ -28,10 +30,11 @@ mock_releases_was = [{
 
 class TestRelease(unittest.TestCase):
     def test_get_release(self):
-        with patch("app.routers.release.get_was_url", return_value=None):
-            response = client.get("/api/release?type=was")
+        with patch("app.routers.release.get_releases_willow", return_value=mock_releases_willow):
+            with patch("app.routers.release.get_was_url", return_value=None):
+                response = client.get("/api/release?type=was")
 
-            assert response.status_code == 500
+                assert response.status_code == 500
 
         with patch("app.routers.release.get_releases_willow", return_value=mock_releases_willow):
             response = client.get("/api/release?type=willow")
@@ -40,7 +43,51 @@ class TestRelease(unittest.TestCase):
             assert json.loads(response.content) == mock_releases_willow
 
             with patch("app.routers.release.get_was_url", return_value="ws://was.local/ws"):
-                response = client.get("/api/release?type=was")
+                with patch("app.routers.release.os.path.isfile", return_value=True):
+                    response = client.get("/api/release?type=was")
 
                 assert response.status_code == 200
                 assert json.loads(response.content) == mock_releases_was
+
+    def test_incompatible_releases_are_not_offered(self):
+        releases = [
+            {
+                "name": "0.5.0",
+                "tag_name": "0.5.0",
+                "latest": True,
+                "prerelease": False,
+                "assets": [{
+                    "browser_download_url": "bogus",
+                    "platform": "ESP32-S3-BOX-3",
+                }],
+            },
+            {
+                "name": "0.4.3",
+                "tag_name": "0.4.3",
+                "latest": False,
+                "prerelease": False,
+                "assets": [{
+                    "browser_download_url": "bogus",
+                    "platform": "ESP32-S3-BOX-3",
+                }],
+            },
+        ]
+
+        with patch("app.routers.release.get_releases_willow", return_value=releases):
+            with patch("app.routers.release.get_was_url", return_value="ws://was.local/ws"):
+                response = client.get("/api/release?type=was")
+
+        assert response.status_code == 200
+        response_releases = json.loads(response.content)
+
+        incompatible = response_releases[0]
+        assert incompatible["was_compatible"] is False
+        assert incompatible["latest"] is False
+        assert "was_url" not in incompatible["assets"][0]
+
+        compatible = response_releases[1]
+        assert compatible["was_compatible"] is True
+        assert compatible["latest"] is True
+        assert compatible["assets"][0]["was_url"] == (
+            "http://was.local/api/ota?version=0.4.3&platform=ESP32-S3-BOX-3"
+        )

--- a/app/pytest/test_willow_release_compatibility.py
+++ b/app/pytest/test_willow_release_compatibility.py
@@ -1,0 +1,23 @@
+import pytest
+
+from app.internal.was import is_willow_release_compatible
+
+
+@pytest.mark.parametrize(
+    ("version", "compatible"),
+    [
+        ("0.4.3", True),
+        ("v0.4.3", True),
+        ("0.5.0-alpha.1", True),
+        ("0.5.0-alpha.99", True),
+        ("0.5.0-beta.0", False),
+        ("0.5.0-beta.1", False),
+        ("0.5.0", False),
+        ("0.5.0-rc.1", False),
+        ("1.0.0", False),
+        ("local", True),
+        ("development", True),
+    ],
+)
+def test_is_willow_release_compatible(version, compatible):
+    assert is_willow_release_compatible(version) is compatible

--- a/app/routers/ota.py
+++ b/app/routers/ota.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel, Field
 from requests import get
 
 from ..const import DIR_OTA
-from ..internal.was import get_releases_willow, get_safe_path
+from ..internal.was import (
+    get_releases_willow,
+    get_safe_path,
+    is_willow_release_compatible,
+)
 
 
 log = getLogger("WAS")
@@ -24,6 +28,12 @@ class GetOta(BaseModel):
 @router.get("/ota")
 async def api_get_ota(ota: GetOta = Depends()):
     log.debug('API GET OTA: Request')
+    if not is_willow_release_compatible(ota.version):
+        raise HTTPException(
+            status_code=409,
+            detail="This Willow release requires a newer Willow Application Server",
+        )
+
     ota_dir = get_safe_path(DIR_OTA, os.path.join(DIR_OTA, ota.version))
     ota_file = os.path.join(ota_dir, f"{ota.platform}.bin")
     ota_file = get_safe_path(ota_dir, ota_file)

--- a/app/routers/release.py
+++ b/app/routers/release.py
@@ -10,7 +10,13 @@ from pydantic import BaseModel, Field
 from requests import get
 
 from ..const import DIR_OTA
-from ..internal.was import get_release_url, get_releases_willow, get_safe_path, get_was_url
+from ..internal.was import (
+    get_release_url,
+    get_releases_willow,
+    get_safe_path,
+    get_was_url,
+    is_willow_release_compatible,
+)
 
 
 log = getLogger("WAS")
@@ -33,10 +39,29 @@ async def api_get_release(release: GetRelease = Depends()):
             raise HTTPException(status_code=500, detail="WAS URL not set")
 
         try:
+            latest_compatible_found = False
             for release in releases:
                 tag_name = release["tag_name"]
+                compatible = is_willow_release_compatible(tag_name)
+                release["was_compatible"] = compatible
+
+                release["latest"] = False
+                if (
+                    compatible
+                    and tag_name != "local"
+                    and not release.get("prerelease", False)
+                    and not latest_compatible_found
+                ):
+                    release["latest"] = True
+                    latest_compatible_found = True
+
                 assets = release["assets"]
                 for asset in assets:
+                    if not compatible:
+                        asset.pop("was_url", None)
+                        asset.pop("cached", None)
+                        continue
+
                     platform = asset["platform"]
                     asset["was_url"] = get_release_url(was_url, tag_name, platform)
                     ota_path = os.path.join(DIR_OTA, tag_name, f"{platform}.bin")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "PyYAML==6.0.3",
     "psycopg2==2.9.12",
     "requests==2.34.2",
+    "semver==3.0.4",
     "sniffio==1.3.1",
     "sqlmodel==0.0.39",
     "starlette==1.3.1",

--- a/uv.lock
+++ b/uv.lock
@@ -712,6 +712,15 @@ wheels = [
 ]
 
 [[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1121,6 +1130,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "semver" },
     { name = "sniffio" },
     { name = "sqlmodel" },
     { name = "starlette" },
@@ -1165,6 +1175,7 @@ requires-dist = [
     { name = "python-multipart", specifier = "==0.0.32" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "requests", specifier = "==2.34.2" },
+    { name = "semver", specifier = "==3.0.4" },
     { name = "sniffio", specifier = "==1.3.1" },
     { name = "sqlmodel", specifier = "==0.0.39" },
     { name = "starlette", specifier = "==1.3.1" },


### PR DESCRIPTION
Hide Willow 0.5 beta and newer releases from WAS OTA selection while exposing compatibility metadata for the UI warning.