### PR TITLE
db: preserve legacy configuration files

### DIFF
--- a/app/db/main.py
+++ b/app/db/main.py
@@ -102,9 +102,9 @@ def migrate_user_config(config):
         try:
             session.commit()
         except IntegrityError as e:
-            # TODO avoid users thinking something is wrong here
             log.warning(e)
             session.rollback()
+            raise
 
 
 def migrate_user_client_config(clients):
@@ -121,9 +121,9 @@ def migrate_user_client_config(clients):
         try:
             session.commit()
         except IntegrityError as e:
-            # TODO avoid users thinking something is wrong here
             log.warning(e)
             session.rollback()
+            raise
 
 
 def migrate_user_nvs(config):
@@ -156,9 +156,9 @@ def migrate_user_nvs(config):
         try:
             session.commit()
         except IntegrityError as e:
-            # TODO avoid users thinking something is wrong here
             log.warning(e)
             session.rollback()
+            raise
 
 
 def save_client_config_to_db(clients):

--- a/app/internal/migration.py
+++ b/app/internal/migration.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from shutil import copy2
+
+
+LEGACY_BACKUP_SUFFIX = ".pre-0.3.0"
+
+
+def backup_legacy_file(path: str | Path) -> Path | None:
+    source_path = Path(path)
+    if not source_path.is_file():
+        return None
+
+    backup_path = source_path.with_name(f"{source_path.name}{LEGACY_BACKUP_SUFFIX}")
+    if backup_path.exists():
+        return None
+
+    temporary_path = backup_path.parent / f".{backup_path.name}.tmp"
+    copy2(source_path, temporary_path)
+    temporary_path.replace(backup_path)
+
+    return backup_path

--- a/app/internal/was.py
+++ b/app/internal/was.py
@@ -113,16 +113,14 @@ def get_config():
 
 
 def get_devices():
-    devices = []
+    if not os.path.isfile(STORAGE_USER_CLIENT_CONFIG):
+        return []
 
-    if os.path.isfile(STORAGE_USER_CLIENT_CONFIG):
-        with open(STORAGE_USER_CLIENT_CONFIG, "r") as devices_file:
-            devices = json.load(devices_file)
-        devices_file.close()
-    else:
-        with open(STORAGE_USER_CLIENT_CONFIG, "x") as devices_file:
-            json.dump(devices, devices_file)
-        devices_file.close()
+    with open(STORAGE_USER_CLIENT_CONFIG, "r") as devices_file:
+        devices = json.load(devices_file)
+
+    if not isinstance(devices, list):
+        raise ValueError("legacy user client configuration is not a list")
 
     return devices
 

--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ from app.internal.command_endpoints import (
     CommandEndpointRuntimeException
 )
 from app.internal.command_endpoints.main import init_command_endpoint
+from app.internal.migration import backup_legacy_file
 from app.internal.was import (
     build_msg,
     get_config,
@@ -78,10 +79,12 @@ def db_migrations():
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    migrate_user_files()
+    backup_legacy_user_files()
+
     # database schema migrations
     db_migrations()
 
-    migrate_user_files()
     get_tz_config(refresh=True)
 
     user_config = get_config()
@@ -149,6 +152,17 @@ def migrate_user_files():
             dest = f"storage/{user_file}"
             if not os.path.isfile(dest):
                 move(user_file, dest)
+
+
+def backup_legacy_user_files():
+    for user_file in (
+        STORAGE_USER_CONFIG,
+        STORAGE_USER_NVS,
+        STORAGE_USER_CLIENT_CONFIG,
+    ):
+        backup_path = backup_legacy_file(user_file)
+        if backup_path is not None:
+            log.info(f"backed up legacy user configuration to {backup_path}")
 
 
 def hex_mac(mac):

--- a/app/main.py
+++ b/app/main.py
@@ -105,11 +105,11 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             log.error(f"failed to migrate user nvs to database: {e}")
 
-    devices = get_devices()
-    # skip migration if devices is empty
-    if devices:
+    if os.path.isfile(STORAGE_USER_CLIENT_CONFIG):
         try:
-            migrate_user_client_config(devices)
+            devices = get_devices()
+            if devices:
+                migrate_user_client_config(devices)
             os.remove(STORAGE_USER_CLIENT_CONFIG)
         except Exception as e:
             log.error(f"failed to migrate user client config to database: {e}")

--- a/app/pytest/test_legacy_migration.py
+++ b/app/pytest/test_legacy_migration.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from app.internal.migration import LEGACY_BACKUP_SUFFIX, backup_legacy_file
+
+
+def test_backup_legacy_file_preserves_original(tmp_path):
+    source_path = tmp_path / "user_config.json"
+    source_path.write_text('{"original": true}')
+
+    backup_path = backup_legacy_file(source_path)
+
+    assert backup_path == Path(f"{source_path}{LEGACY_BACKUP_SUFFIX}")
+    assert backup_path.read_text() == source_path.read_text()
+
+
+def test_backup_legacy_file_does_not_overwrite_existing_backup(tmp_path):
+    source_path = tmp_path / "user_config.json"
+    source_path.write_text('{"original": true}')
+    backup_path = backup_legacy_file(source_path)
+    source_path.write_text('{"updated": true}')
+
+    assert backup_legacy_file(source_path) is None
+    assert backup_path.read_text() == '{"original": true}'
+
+
+def test_backup_legacy_file_ignores_missing_source(tmp_path):
+    assert backup_legacy_file(tmp_path / "missing.json") is None

--- a/app/pytest/test_legacy_migration.py
+++ b/app/pytest/test_legacy_migration.py
@@ -1,9 +1,31 @@
 from pathlib import Path
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
+from app.db import main as db
 from app.internal import was
 from app.internal.migration import LEGACY_BACKUP_SUFFIX, backup_legacy_file
+
+
+class FailingSession:
+    def __init__(self):
+        self.rolled_back = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def add(self, record):
+        pass
+
+    def commit(self):
+        raise IntegrityError("statement", {}, RuntimeError("migration failed"))
+
+    def rollback(self):
+        self.rolled_back = True
 
 
 def test_backup_legacy_file_preserves_original(tmp_path):
@@ -45,3 +67,30 @@ def test_get_devices_rejects_invalid_legacy_file(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="is not a list"):
         was.get_devices()
+
+
+@pytest.mark.parametrize(
+    ("migrate", "content"),
+    [
+        (db.migrate_user_config, {"aec": True}),
+        (
+            db.migrate_user_nvs,
+            {
+                "WAS": {"URL": "http://was.example/ws"},
+                "WIFI": {"PSK": "secret", "SSID": "willow"},
+            },
+        ),
+        (
+            db.migrate_user_client_config,
+            [{"label": "Kitchen", "mac_addr": "00:11:22:33:44:55"}],
+        ),
+    ],
+)
+def test_failed_database_migration_is_reported(monkeypatch, migrate, content):
+    session = FailingSession()
+    monkeypatch.setattr(db, "Session", lambda engine: session)
+
+    with pytest.raises(IntegrityError):
+        migrate(content)
+
+    assert session.rolled_back is True

--- a/app/pytest/test_legacy_migration.py
+++ b/app/pytest/test_legacy_migration.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import pytest
+
+from app.internal import was
 from app.internal.migration import LEGACY_BACKUP_SUFFIX, backup_legacy_file
 
 
@@ -25,3 +28,20 @@ def test_backup_legacy_file_does_not_overwrite_existing_backup(tmp_path):
 
 def test_backup_legacy_file_ignores_missing_source(tmp_path):
     assert backup_legacy_file(tmp_path / "missing.json") is None
+
+
+def test_get_devices_does_not_create_missing_legacy_file(tmp_path, monkeypatch):
+    source_path = tmp_path / "user_client_config.json"
+    monkeypatch.setattr(was, "STORAGE_USER_CLIENT_CONFIG", str(source_path))
+
+    assert was.get_devices() == []
+    assert source_path.exists() is False
+
+
+def test_get_devices_rejects_invalid_legacy_file(tmp_path, monkeypatch):
+    source_path = tmp_path / "user_client_config.json"
+    source_path.write_text("{}")
+    monkeypatch.setattr(was, "STORAGE_USER_CLIENT_CONFIG", str(source_path))
+
+    with pytest.raises(ValueError, match="is not a list"):
+        was.get_devices()


### PR DESCRIPTION
## Summary
- Copy legacy JSON configuration files to `.pre-0.3.0` backups before database migration, preserving the first backup for WAS 0.2.x downgrades.
- Stop creating an empty `user_client_config.json`; remove a valid legacy file after backup even when it contains no clients, while retaining malformed data for recovery.
- Re-raise `IntegrityError` after rollback so startup does not delete the original JSON file when a database migration fails.

## Testing
- 22 focused tests pass.
- All GitHub Actions checks pass.